### PR TITLE
Fixed caching issue

### DIFF
--- a/lib/googleCalendar.js
+++ b/lib/googleCalendar.js
@@ -7,7 +7,11 @@ export async function getNextMeeting() {
   const url = `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_ID}/events?key=${API_KEY}&timeMin=${new Date().toISOString()}&singleEvents=true&orderBy=startTime&maxResults=1`;
 
   try {
-    const response = await fetch(url, { next: { revalidate: 60 } });
+    const response = await fetch(url, {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    });
     if (!response.ok) {
       throw new Error("Failed to fetch events from Google Calendar API");
     }


### PR DESCRIPTION
The key change is the addition of the headers object to the fetch call. By setting 'Cache-Control': 'no-store, max-age=0', we are explicitly telling any intermediary cache, including Cloudflare's, not to store the response and to consider it stale immediately. This ensures that a new request is made to the Google Calendar API on every function invocation, resolving the issue of the meeting getting stuck.